### PR TITLE
Use local Atom feed instead of feedburner

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,6 @@ author :
   email : aleks@opentechschool.org
   github : OpenTechSchool
   twitter : opentechschool 
-  feedburner : opentechschool
 
 # The production_url is only used when full-domain names are needed
 # such as sitemap.txt 

--- a/_includes/themes/ots/default.html
+++ b/_includes/themes/ots/default.html
@@ -9,7 +9,7 @@
 	
   <title>{{ page.title }}</title>
 
-	<link href="http://feeds.feedburner.com/{{ site.author.feedburner }}" rel="alternate" title="your title" type="application/atom+xml" />
+  <link href="{{ site.production_url }}/atom.xml" rel="alternate" title="{{ site.title }} Feed" type="application/atom+xml" />
 
 	 <!-- syntax highlighting CSS -->
 	<link rel="stylesheet" href="{{ ASSET_PATH }}/css/syntax.css" type="text/css" />


### PR DESCRIPTION
We can host the atom feed locally for now. If we become so incredibly popular that we can't support it anymore (nice problem to have) then we can send out a redirect post through the feed to send people to the new URL.
