### PR TITLE
Groups Signup Form Feature for BlogPosts

### DIFF
--- a/_includes/mailinglist_signup.html
+++ b/_includes/mailinglist_signup.html
@@ -1,0 +1,19 @@
+
+
+<div>
+  <img src="http://groups.google.com/intl/en/images/logos/groups_logo_sm.gif"
+         style="height:30px; width:140px; float:left; padding-top:25px" alt="Google Groups">
+
+  <div style="margin-left: 160px">
+    <b>Sign up for {{group_title}}</b>
+    </td></tr>
+    <form action="http://groups.google.com/a/opentechschool.org/group/{{group_name}}/boxsubscribe">
+    Email: <input type=text name=email>
+    <br>
+      <input type=submit name="sub" value="Sign up">&nbsp;or&nbsp;<a href="http://groups.google.com/a/opentechschool.org/group/{{group_name}}">visit it</a>
+    </form>
+
+
+  </div>
+  <br style="clear:both">
+</div>

--- a/_includes/themes/ots/post.html
+++ b/_includes/themes/ots/post.html
@@ -10,6 +10,13 @@
     {{ page.date | date_to_long_string }}
   </span>
 	{{ content }}
+
+	{% if page.group_signup %}
+		{% assign group_title = page.group_title %}
+		{% assign group_name = page.group_name %}
+
+		{% include mailinglist_signup.html %}
+	{% endif %}
 	
 	<div id="related">
 		<h2><span>Related Posts</span></h2>

--- a/_posts/2012-07-11-announcing-ots-camp-at-campuspartyeu.md
+++ b/_posts/2012-07-11-announcing-ots-camp-at-campuspartyeu.md
@@ -7,6 +7,10 @@ author: "Benjamin Kampmann"
 tags: ["festival", "campuspartyeu", "campusparty", "ots camp", "berlin", "ots", "tempelhof"]
 teaser: "I'm very glad to announce that [OpenTechSchool will be offering workshops during CampusParty](http://www.campus-party.eu/2012/developers.html#OpenTechSchool). Yes, we will participate in this week-long tech event, taking place on Tempelhofer Feld in Berlin from August 21 to the 26th. With 10,000 participants, developers, and tech enthusiasts from all over Europe, and over 600 hours of content, workshops, hackathons, presentations, and who knows what else, it will be one of the biggest tech events this city has ever seen. Awesome, right?"
 
+group_signup: 1
+group_title: OTSCamp Coaches
+group_name: otscamp-coaches
+
 ---
 
 {% include JB/setup %}


### PR DESCRIPTION
Hi there,

I added the promised "Signup for Google Group" Form feature for the blog posts. You can now easily specify a form-signup under any blog post as I as an example for OTSCamp (soo see meta config setup for that as an example).

Please review and push. We could use it for the 3d-math call for coaches next week.

Greets
Bn
