### PR TITLE
Proxima Nova disallowed, switch to Source Sans Pro

### DIFF
--- a/_includes/themes/ots/default.html
+++ b/_includes/themes/ots/default.html
@@ -4,7 +4,7 @@
 <!--[if IE 8]>		<html class="no-js ie8 oldie" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
-	<meta charset="UFT-8">
+	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	
   

--- a/_includes/themes/ots/default.html
+++ b/_includes/themes/ots/default.html
@@ -4,7 +4,7 @@
 <!--[if IE 8]>		<html class="no-js ie8 oldie" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
-	<meta charset="utf-8">
+	<meta charset="UFT-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	
   
@@ -70,15 +70,14 @@
 	<link rel="stylesheet" href="{{ ASSET_PATH }}/css/style.css" type="text/css" />
 	<link rel="stylesheet" href="{{ ASSET_PATH }}/css/grid.css" type="text/css" />
 	<link rel="stylesheet" href="{{ ASSET_PATH }}/css/blog.css" type="text/css" />
+	
+	<!-- Fonts -->
+	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic|Inconsolata' rel='stylesheet' type='text/css'>
   
 	<!--[if lt IE 9]>
 	<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
 	<!-- end CSS-->
-  
-	<!-- Typekit -->
-	<script type="text/javascript" src="http://use.typekit.com/jpd0pfm.js"></script>
-	<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 </head>
 <body>
 

--- a/assets/themes/ots/css/style.css
+++ b/assets/themes/ots/css/style.css
@@ -29,7 +29,7 @@ dfn, i, em { font-style: italic; }
 hr { display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin: 1em 0; padding: 0; }
 ins { background: #ff9; color: #000; text-decoration: none; }
 mark { background: #ff0; color: #000; font-style: italic; font-weight: bold; }
-pre, code, kbd, samp { font-family: Consolas, "Inconsolata", "Liberation Mono", fCourier, monospace; font-size: 1em; }
+pre, code, kbd, samp { font-family: Consolas, "Inconsolata", "Liberation Mono", "Ubuntu Mono", Courier, monospace; font-size: 1em; }
 pre { white-space: pre; white-space: pre-wrap; word-wrap: break-word; }
 q { quotes: none; }
 q:before, q:after { content: ""; content: none; }

--- a/assets/themes/ots/css/style.css
+++ b/assets/themes/ots/css/style.css
@@ -11,7 +11,7 @@ audio:not([controls]) { display: none; }
 
 html { font-size: 100%; overflow-y: scroll; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
 body { margin: 0; font-size: 18px; line-height: 1.5; }
-body, button, input, select, textarea { font-family: "proxima-nova-alt", "Helvetica Neue", Arial, Helvetica, sans-serif; color: #222; }
+body, button, input, select, textarea { font-family: "Source Sans Pro", "Helvetica Neue", Arial, Helvetica, sans-serif; color: #222; }
 
 ::-moz-selection { background: #fd4b22; color: #fff; text-shadow: none; }
 ::selection { background: #fd4b22; color: #fff; text-shadow: none; }
@@ -29,7 +29,7 @@ dfn, i, em { font-style: italic; }
 hr { display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin: 1em 0; padding: 0; }
 ins { background: #ff9; color: #000; text-decoration: none; }
 mark { background: #ff0; color: #000; font-style: italic; font-weight: bold; }
-pre, code, kbd, samp { font-family: monospace, monospace; _font-family: font-family: Consolas, "Liberation Mono", Courier, monospace; font-size: 1em; }
+pre, code, kbd, samp { font-family: Consolas, "Inconsolata", "Liberation Mono", fCourier, monospace; font-size: 1em; }
 pre { white-space: pre; white-space: pre-wrap; word-wrap: break-word; }
 q { quotes: none; }
 q:before, q:after { content: ""; content: none; }


### PR DESCRIPTION
Adobe typekit was broken, specifically because we were trying to use the script generated for tom.preston-werner.com's account (CEO of github)

https://typekit.com/colophons/jpd0pfm <- link if you click on the "powered by typekit" button on bottom right corner of the blog

I replaced it with google web fonts and Source Sans Pro, which is a very similar account.

Inconsolata was added as well, since that was what was requested, and its very similar to Consolas, which is what you'll see if you're on windows (Inconsolata is a free font though).
